### PR TITLE
[LFI-18/feat] 비로그인/로그인 프로필 UI 구현

### DIFF
--- a/Lyfe/Projects/Feature/FeedFeature/Sources/FeedHome/FeedHomeView.swift
+++ b/Lyfe/Projects/Feature/FeedFeature/Sources/FeedHome/FeedHomeView.swift
@@ -62,7 +62,7 @@ struct detailView: View {
             case .new:
                 LazyVGrid(columns: columns, spacing: 12) {
                         ForEach((0...19), id: \.self) { _ in
-                            FeedGridItem()
+                            DefaultFeed()
                                 .onTapGesture {
                                     store.send(.moveToDetail)
                                 }
@@ -72,7 +72,7 @@ struct detailView: View {
             case .popular:
                 LazyVGrid(columns: columns,spacing: 12) {
                         ForEach((0...19), id: \.self) { _ in
-                            FeedGridItem()
+                            DefaultFeed()
                                 .onTapGesture {
                                     store.send(.moveToDetail)
                                 }

--- a/Lyfe/Projects/Feature/ProfileFeature/Demo/Sources/AppDelegate.swift
+++ b/Lyfe/Projects/Feature/ProfileFeature/Demo/Sources/AppDelegate.swift
@@ -1,4 +1,6 @@
 import UIKit
+import SwiftUI
+import ProfileFeature
 
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -9,11 +11,17 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        let viewController = UIViewController()
-        viewController.view.backgroundColor = .yellow
-        window?.rootViewController = viewController
+        let splashView = ProfileCoordinatorView(
+            store: .init(
+                initialState: ProfileCoordinator.State.init()
+            ) {
+                ProfileCoordinator()
+            }
+        )
+        window?.rootViewController = UIHostingController(rootView: splashView)
         window?.makeKeyAndVisible()
-
+        
+        
         return true
     }
 }

--- a/Lyfe/Projects/Feature/ProfileFeature/Sources/Profile/ProfileView.swift
+++ b/Lyfe/Projects/Feature/ProfileFeature/Sources/Profile/ProfileView.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import ComposableArchitecture
 import DesignSystem
 
+
+enum ProfileTap: String, CaseIterable {
+    case photo = "신청 사진"
+    case text = "고민 글"
+}
+
+
 struct ProfileView: View {
     let store: StoreOf<ProfileCore>
     
@@ -10,15 +17,166 @@ struct ProfileView: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button {
-                self.store.send(.pushProfileEdit)
-            } label: {
-                Text("Push ProfileEdit")
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 16) {
+                R.Common.avatar
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                
+                VStack(alignment: .leading) {
+                    Text("익명의 쿼카")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(.black)
+                    
+                    Button {
+                        
+                    } label: {
+                        Text("프로필 수정")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(R.Color.grey300)
+                    }
+                }
+                
+            }
+            
+            ProfileTabView(store: self.store)
+        }
+        .padding(.horizontal, 20)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: {
+                    
+                }, label: {
+                    R.Common.arrowBack
+                })
+            }
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    
+                }, label: {
+                    Text("설정")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(R.Color.black)
+                })
             }
         }
-        .topBar(centerView: { Text("Profile") })
         .background(Color.white)
         .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+
+struct detailView: View {
+    
+    let store: StoreOf<ProfileCore>
+    var feedTabs: ProfileTap
+    
+    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
+    
+    var body: some View {
+        //비로그인
+//        switch feedTabs {
+//        case .photo:
+//            nonLoginView()
+//        case .text:
+//            nonLoginView()
+//        }
+        //로그인
+        ScrollView(.vertical, showsIndicators: false) {
+            switch feedTabs {
+            case .photo:
+                LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach((0...19), id: \.self) { _ in
+                            DefaultFeed()
+                        }
+                    }
+            case .text:
+                LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach((0...19), id: \.self) { _ in
+                            DefaultFeed()
+                        }
+                    }
+            }
+        }
+    }
+}
+
+struct nonLoginView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: 40) {
+            Spacer()
+            
+            Text("로그인 하시면 신청한 사진, \n작성한 고민글을 모아 볼 수 있어요")
+                .font(.system(size: 18, weight: .bold))
+                .multilineTextAlignment(.center)
+                .foregroundColor(R.Color.grey900)
+                .frame(alignment: .center)
+            
+            Button {
+                
+            } label: {
+                Text("로그인 하러 가기")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(height: 48)
+                    .padding(.horizontal, 24)
+                    .background(R.Color.mainOrange500)
+                    .cornerRadius(8)
+            }
+            
+           
+            Text("아직 회원이 아니신가요?")
+                .font(.system(size: 14))
+                .multilineTextAlignment(.center)
+                .foregroundColor(R.Color.grey500)
+                .padding(.horizontal, 100)
+                .padding(.top, -32)
+                     
+            Spacer()
+        }
+    }
+}
+
+
+
+struct ProfileTabView: View {
+    let store: StoreOf<ProfileCore>
+    
+    @State private var selectedPicker: ProfileTap = .photo
+    @Namespace private var animation
+    
+    var body: some View {
+        VStack {
+            animate()
+            detailView(store: self.store, feedTabs: selectedPicker)
+        }
+    }
+    
+    @ViewBuilder
+    private func animate() -> some View {
+        HStack {
+            ForEach(ProfileTap.allCases, id: \.self) { item in
+                VStack {
+                    Text(item.rawValue)
+                        .frame(maxWidth: .infinity/4, minHeight: 32)
+                        .font(selectedPicker == item ? .system(size: 18, weight: .bold): .system(size: 18, weight: .medium) )
+                        .foregroundColor(selectedPicker == item ? R.Color.mainOrange500: R.Color.grey200)
+                    
+                    if selectedPicker == item {
+                        Capsule()
+                            .foregroundColor(R.Color.mainOrange500)
+                            .frame(height: 2)
+                            .font(.title3)
+                            .matchedGeometryEffect(id: "info", in: animation)
+                    }
+                }
+                .onTapGesture {
+                    withAnimation(.easeInOut) {
+                        self.selectedPicker = item
+                    }
+                }
+            }
+        }
     }
 }

--- a/Lyfe/Projects/UserInterface/DesignSystem/Sources/Component/DefaultFeed.swift
+++ b/Lyfe/Projects/UserInterface/DesignSystem/Sources/Component/DefaultFeed.swift
@@ -7,10 +7,13 @@
 //
 
 import SwiftUI
-import DesignSystem
 
-struct FeedGridItem: View {
-    var body: some View {
+public struct DefaultFeed: View {
+    public init() {
+        
+    }
+    
+    public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             VStack(alignment: .leading) {
                 HStack(spacing: 4) {
@@ -72,6 +75,3 @@ struct FeedGridItem: View {
     }
 }
 
-#Preview {
-    FeedGridItem()
-}


### PR DESCRIPTION
## ✈️ 지라 백로그
- [LFI-18](https://lyfe2024.atlassian.net/browse/LFI-18) 백로그 내용

<br>

## 👾 작업 내용
- 로그인, 비로그인 프로필 UI 구현
- 피드 Grid Item Design System으로 이동

<br>

## 📸 스크린샷
<p >
<img width="350" alt="스크린샷 2023-12-19 오후 11 11 17" src="https://github.com/lyfe2024/lyfe-iOS/assets/81149634/f94ebae8-c97f-42e3-a463-caaa92ea8ac5">
<img width="350 alt="스크린샷 2023-12-19 오후 11 25 53" src="https://github.com/lyfe2024/lyfe-iOS/assets/81149634/a11175ae-c6d7-4d07-9564-06d9779cc3ba">
</p>


<br>

## 🎸 기타 사항
- 


[LFI-18]: https://lyfe2024.atlassian.net/browse/LFI-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ